### PR TITLE
add stack.yaml with lts-6.35 (ghc-7.10.3)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-6.35


### PR DESCRIPTION
lts-7.24 (ghc-8.0.1) would also work but rather not target non-final ghc releases